### PR TITLE
Remove old waffle and mocha files

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,6 +1,0 @@
-{
-  "extension": ["ts"],
-  "spec": "./test/**/*.ts",
-  "require": "ts-node/register",
-  "timeout": 12000
-}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,0 @@
--r ts-node/register/transpile-only
---timeout 50000
---no-warnings
-test/**/*.test.{js,ts}

--- a/waffle.json
+++ b/waffle.json
@@ -1,6 +1,0 @@
-{
-  "compilerVersion": "0.6.12",
-  "compilerType": "solcjs",
-  "sourceDirectory": "./src/contracts",
-  "outputDirectory": "./build"
-}


### PR DESCRIPTION
These Waffle and Mocha configuration files are no longer used as `buidler` configures this for us (with settings from `buidler.config.ts`).

### Test Plan

CI - test still run and pass :tada: 