### PR TITLE
Settlement contract

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -3,7 +3,6 @@
   "plugins": ["prettier"],
   "rules": {
     "compiler-version": ["error", "^0.6.12"],
-    "func-visibility": ["warn", { "ignoreConstructors": true }],
     "prettier/prettier": "error"
   }
 }

--- a/.solhint.json
+++ b/.solhint.json
@@ -3,6 +3,7 @@
   "plugins": ["prettier"],
   "rules": {
     "compiler-version": ["error", "^0.6.12"],
+    "func-visibility": ["warn", { "ignoreConstructors": true }],
     "prettier/prettier": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "test": "buidler test",
     "lint": "yarn lint:sol && yarn lint:ts",
     "lint:sol": "solhint 'src/contracts/**/*.sol'",
-    "lint:ts": "eslint --max-warnings 0 ."
+    "lint:ts": "eslint --max-warnings 0 .",
+    "fmt:sol": "prettier 'src/contracts/**/*.sol' -w"
   },
   "devDependencies": {
     "@nomiclabs/buidler": "^1.4.8",

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -1,0 +1,91 @@
+// SPDX-license-identifier: LGPL-3.0-or-newer
+pragma solidity ^0.6.12;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Factory.sol";
+
+/// @title Gnosis Protocol v2 Settlement Contract
+/// @author Gnosis Developers
+contract GPv2Settlement {
+    /// @dev The domain separator used for signing orders that gets mixed in
+    /// making signatures for different domains incompatible.
+    bytes32 public constant DOMAIN_SEPARATOR = keccak256("GPv2");
+
+    /// @dev The stride of an encoded order.
+    uint256 private constant ORDER_STRIDE = 120;
+
+    /// @dev The Uniswap factory. This is used as the AMM that GPv2 settles with
+    /// and is responsible for determining the range of the settlement price as
+    /// well as trading surplus that cannot be directly settled in a batch.
+    IUniswapV2Factory public immutable uniswap;
+
+    /// @dev The global nonce for determining the current batch. This is used to
+    /// ensure orders can't be replayed in multiple batches.
+    uint256 public nonce;
+
+    /// @param uniswap The Uniswap factory to act as the AMM for this GPv2
+    /// settlement contract.
+    constructor(IUniswapV2Factory uniswap_) {
+        uniswap = uniswap_;
+    }
+
+    /// @dev Settle the specified orders at a clearing price. Note that it is
+    /// the responsibility of the caller to ensure that all GPv2 invariants are
+    /// upheld for the input settlement, otherwise this call will revert.
+    /// Namely:
+    /// - The prices are better than, or equal to, the AMM's price with its fee
+    ///   spread. Specifically the price is either:
+    ///   - Effective price in case the AMM was traded with,
+    ///   - Spot price in case the AMM was not traded with.
+    /// - All orders are valid and signed
+    /// - Accounts have sufficient balance and approval.
+    ///
+    /// Note that orders in this method are expressed as encoded bytes. These
+    /// bytes are tightly packed orders encoded with `abi.encodePacked` in order
+    /// to reduce the amount of call data required to call this method. Orders
+    /// encode the following fields:
+    /// ```
+    /// struct Order {
+    ///     sellAmount: uint112,
+    ///     buyAmount:  uint112,
+    ///     validTo:    uint32,
+    ///     nonce:      uint32,
+    ///     tip:        uint112,
+    ///     validTo:    uint32,
+    ///     flags:      uint8,
+    ///     signature: {
+    ///         v: uint8,
+    ///         r: bytes32,
+    ///         s: bytes32,
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Note that the encoded order data does not contain which token is the
+    /// sell or buy token. This data is implicit from which parameter the order
+    /// was specified from.
+    ///
+    /// @param token0 The address of token 0 being traded in the batch.
+    /// @param token1 The address of token 1 being traded in the batch.
+    /// @param d0 The amount of token 0 being traded to the AMM.
+    /// @param d1 The amount of token 1 being traded to the AMM.
+    /// @param clearingPrice0 The price of token 0 expressed in arbitrary units.
+    /// Note the exchange rate between token 0 and token 1 is `price1 / price0`.
+    /// @param clearingPrice1 The price of token 1 expressed in arbitrary units.
+    /// Note the exchange rate between token 1 and token 0 is `price0 / price1`.
+    /// @param encodedOrders0 All orders trading token 0 for token 1, that is,
+    /// either orders selling token 0 for token 1 or buying token 1 for token 0.
+    /// @param encodedOrders1 All orders trading token 1 for token 2.
+    function settle(
+        IERC20 token0,
+        IERC20 token1,
+        int256 d0,
+        int256 d1,
+        uint256 clearingPrice0,
+        uint256 clearingPrice1,
+        bytes calldata encodedOrders0,
+        bytes calldata encodedOrders1
+    ) external {
+        revert("not yet implemented");
+    }
+}

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -95,8 +95,12 @@ contract GPv2Settlement {
     /// @param token0 The address one of the tokens of the pair.
     /// @param token1 The address the other token of the pair.
     /// @return The token ID unique to the pair.
-    function pairId(IERC20 token0, IERC20 token1) public pure returns (bytes20) {
-      require(token0 != token1, "invalid pair");
-      return (bytes20(address(token0)) ^ bytes20(address(token1)));
+    function pairId(IERC20 token0, IERC20 token1)
+        public
+        pure
+        returns (bytes20)
+    {
+        require(token0 != token1, "invalid pair");
+        return (bytes20(address(token0)) ^ bytes20(address(token1)));
     }
 }

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -17,16 +17,16 @@ contract GPv2Settlement {
     /// @dev The Uniswap factory. This is used as the AMM that GPv2 settles with
     /// and is responsible for determining the range of the settlement price as
     /// well as trading surplus that cannot be directly settled in a batch.
-    IUniswapV2Factory public immutable uniswap;
+    IUniswapV2Factory public immutable uniswapFactory;
 
     /// @dev The global nonce for determining the current batch. This is used to
     /// ensure orders can't be replayed in multiple batches.
     uint256 public nonce;
 
-    /// @param uniswap The Uniswap factory to act as the AMM for this GPv2
-    /// settlement contract.
-    constructor(IUniswapV2Factory uniswap_) {
-        uniswap = uniswap_;
+    /// @param uniswapFactory_ The Uniswap factory to act as the AMM for this
+    /// GPv2 settlement contract.
+    constructor(IUniswapV2Factory uniswapFactory_) public {
+        uniswapFactory = uniswapFactory_;
     }
 
     /// @dev Settle the specified orders at a clearing price. Note that it is

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -37,7 +37,29 @@ describe("GPv2Settlement", () => {
 
   describe("nonce", () => {
     it("should should be initialized to zero", async () => {
-      expect(await settlement.nonce()).to.equal(ethers.constants.Zero);
+      expect(await settlement.nonce(`0x${"42".repeat(20)}`)).to.equal(
+        ethers.constants.Zero,
+      );
+    });
+  });
+
+  describe("pairId", () => {
+    it("should return the same ID regardless of token order", async () => {
+      const [token0, token1] = [
+        `0x${"42".repeat(20)}`,
+        `0x${"1337".repeat(10)}`,
+      ];
+
+      expect(await settlement.pairId(token0, token1)).to.equal(
+        await settlement.pairId(token1, token0),
+      );
+    });
+
+    it("should revert for pairs where both tokens are equal", async () => {
+      const token = `0x${"42".repeat(20)}`;
+      await expect(settlement.pairId(token, token)).to.be.revertedWith(
+        "invalid pair",
+      );
     });
   });
 });

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -1,0 +1,43 @@
+import { ethers, waffle } from "@nomiclabs/buidler";
+import IUniswapV2Factory from "@uniswap/v2-core/build/IUniswapV2Factory.json";
+import { expect } from "chai";
+import { Contract } from "ethers";
+
+describe("GPv2Settlement", () => {
+  const [deployer] = waffle.provider.getWallets();
+
+  let settlement: Contract;
+  let uniswapFactory: Contract;
+
+  beforeEach(async () => {
+    const GPv2Settlement = await ethers.getContractFactory("GPv2Settlement");
+
+    uniswapFactory = await waffle.deployMockContract(
+      deployer,
+      IUniswapV2Factory.abi,
+    );
+    settlement = await GPv2Settlement.deploy(uniswapFactory.address);
+  });
+
+  describe("DOMAIN_SEPARATOR", () => {
+    it("should have a well defined domain separator", async () => {
+      expect(await settlement.DOMAIN_SEPARATOR()).to.equal(
+        ethers.utils.id("GPv2"),
+      );
+    });
+  });
+
+  describe("uniswapFactory", () => {
+    it("should be set by the constructor", async () => {
+      expect(await settlement.uniswapFactory()).to.equal(
+        uniswapFactory.address,
+      );
+    });
+  });
+
+  describe("nonce", () => {
+    it("should should be initialized to zero", async () => {
+      expect(await settlement.nonce()).to.equal(ethers.constants.Zero);
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces a documented settlement contract with some really simple unit tests. I decided to make a PR right away so we can discuss the function signature of the `settle` external function.

A few things to note:
- We use `immutable` instead of storage for the `uniswapFactory`. This has the advantage that it does not perform an `SLOAD` to get the Uniswap address, but it is instead imbedded into the code at deployment :tada: 
- Currently using the global nonce per pair, which is still up for debate. (note that a pair is being uniquely identified as the `XOR` of the token addresses, ensuring that the order in which they are specified does not matter).
- Using a packed order encoding. This will require to manually decode the order. The proposed layout is included in the comments.
- The constants are public but don't need to be. Maybe we can make them internal and then make them public in a "test interface" contract.

### Test Plan

New unit tests.
