### PR TITLE
Alternate `eth_signTypedData` implementation without assembly

### DIFF
--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -232,7 +232,7 @@ describe("GPv2Encoding", () => {
       ).to.be.reverted;
     });
 
-    it("should allocate minimal memory", async () => {
+    it("should not allocate additional memory", async () => {
       // NOTE: We want to make sure that calls to `decodeOrder` does not require
       // additional memory allocations to save on memory per orders.
       //todo
@@ -255,13 +255,7 @@ describe("GPv2Encoding", () => {
         encoder.orderCount,
         encoder.encodedOrders,
       );
-
-      // NOTE: Currently, the `ecrecover` call requires 32 bytes of memory to
-      // be allocated per call. This is because `STATICCALL` writes the output
-      // to memory, and the compiler does not seem to optimize the extra memory
-      // copy away (despite the result being saved immediately to memory). In
-      // the future, we can optimize this away with some `assembly`.
-      expect(mem.toNumber()).to.equal(64);
+      expect(mem.toNumber()).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
Here is an alternate implementation that doesn't make use of assembly. It runs into a couple issues:
- stack too deep error, requiring some manual scoping of variables.
- 482 bytes allocated for decoding 1 order
- 990 bytes allocated for decoding 2 orders

I think the amount of memory being allocated per order justifies the use of assembly.